### PR TITLE
Check for domain_can_mmap_files before setting

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,6 +55,15 @@
   import_role:
     name: robertdebock.service
 
+- name: check for domain_can_mmap_files seboolean
+  command: getsebool domain_can_mmap_files
+  register: getsebool_domain_can_mmap_files
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_selinux.status is defined
+    - ansible_selinux.status == "enabled"
+
 - name: modify selinux settings
   seboolean:
     name: domain_can_mmap_files
@@ -63,6 +72,7 @@
   when:
     - ansible_selinux.status is defined
     - ansible_selinux.status == "enabled"
+    - getsebool_domain_can_mmap_files.rc == 0
 
 - name: start and enable anaconda
   service:


### PR DESCRIPTION
---
name: Pull request
about: Check for existence of `domain_can_mmap_files` SELinux boolean before setting `domain_can_mmap_files`. Fixes #4 

---

**Describe the change**
The `domain_can_mmap_files` SELinux boolean was introduced in RHEL/CentOS 7.6, so setting the `domain_can_mmap_files` seboolean will cause failures on hosts that do not have the `domain_can_mmap_files` seboolean defined.

This change adds a check for the existence of `domain_can_mmap_files` using `getsebool`. If the return code is non-zero, the `domain_can_mmap_files` SELinux boolean does not exist and therefore the `modify selinux settings` task should be skipped.

**Testing**
1. I created VMs running CentOS 7.4 and verified that the `modify selinux settings` step was skipped and the playbook completed successfully.
2. I ran the Molecule tests with `molecule test` and verified that they completed successfully.
3. I ran the [galaxy-lint-rules](https://github.com/ansible/galaxy-lint-rules) and the [robertdebock ansible-lint-rules](https://github.com/robertdebock/ansible-lint-rules) against the code and verified that there were no violations.